### PR TITLE
Fix installation/testing on Debian with OSSP::UUID

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,7 +17,7 @@ my %WriteMakefileArgs = (
   "MIN_PERL_VERSION" => "5.008009",
   "NAME" => "Test2::Plugin::UUID",
   "PREREQ_PM" => {
-    "Data::UUID" => "1.148",
+    "Data::UUID" => "0",
     "Test2::API" => "1.302165"
   },
   "TEST_REQUIRES" => {
@@ -31,7 +31,7 @@ my %WriteMakefileArgs = (
 
 
 my %FallbackPrereqs = (
-  "Data::UUID" => "1.148",
+  "Data::UUID" => "0",
   "Test2::API" => "1.302165",
   "Test2::V0" => "0.000124"
 );

--- a/cpanfile
+++ b/cpanfile
@@ -1,4 +1,4 @@
-requires "Data::UUID" => "1.148";
+requires "Data::UUID" => "0";
 requires "Test2::API" => "1.302165";
 requires "perl" => "5.008009";
 

--- a/dist.ini
+++ b/dist.ini
@@ -30,7 +30,7 @@ repository.type = git
 [Prereqs]
 perl             = 5.008009
 Test2::API       = 1.302165
-Data::UUID       = 1.148
+Data::UUID       = 0
 
 [Prereqs / TestRequires]
 Test2::V0 = 0.000124

--- a/lib/Test2/Plugin/UUID.pm
+++ b/lib/Test2/Plugin/UUID.pm
@@ -9,7 +9,8 @@ use Test2::API qw/test2_add_uuid_via/;
 use Data::UUID;
 my $UG = Data::UUID->new;
 
-sub gen_uuid() { $UG->create_str() }
+# OSSP::UUID (Debian) produces lowercase UUIDs, consistently uppercase.
+sub gen_uuid() { uc $UG->create_str() }
 
 sub import {
     test2_add_uuid_via(\&gen_uuid);


### PR DESCRIPTION
On Debian it's possible to install libossp-uuid-perl which provides a compatible Data::UUID interface. Historically I believe this was for license reasons but there are functional differences too like OSSP providing (and defaulting) to a version 4 (random) UUID which Data::UUID doesn't support.

Becuase the version numbers are wildly different, not specifying our minimum version makes packaging a lot easier also because OSSP correctly produces a lowercase UUID as per the spec then our tests fail without an added uppercase. There's an upstream issue on Data::UUID tracking the mismatched case - https://github.com/bleargh45/Data-UUID/issues/34

This PR is very similar to #1 but with the added `uc` to make the tests pass on Debian under libossp-uuid-perl.